### PR TITLE
feat: export Manager types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from "./structures/NodeManager";
 export * from "./structures/Player";
 export * from "./structures/Queue";
 export * from "./structures/Utils";
+export * from "./structures/Types/Manager";
 export * from "./structures/Types/Track";
 export * from "./structures/Types/Utils";
 export * from "./structures/Types/Filters";


### PR DESCRIPTION
Manager Types is the unique file that is not exported

closes #41 