### PR TITLE
fix manager types

### DIFF
--- a/dist/cjs/index.d.ts
+++ b/dist/cjs/index.d.ts
@@ -13,3 +13,4 @@ export * from "./structures/Types/Player";
 export * from "./structures/Types/Queue";
 export * from "./structures/Types/Node";
 export * from "./structures/Constants";
+export * from "./structures/Types/Manager";

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -16,3 +16,4 @@ tslib_1.__exportStar(require("./structures/Types/Player"), exports);
 tslib_1.__exportStar(require("./structures/Types/Queue"), exports);
 tslib_1.__exportStar(require("./structures/Types/Node"), exports);
 tslib_1.__exportStar(require("./structures/Constants"), exports);
+tslib_1.__exportStar(require("./structures/Types/Manager"), exports);

--- a/dist/esm/index.d.ts
+++ b/dist/esm/index.d.ts
@@ -13,3 +13,4 @@ export * from "./structures/Types/Player";
 export * from "./structures/Types/Queue";
 export * from "./structures/Types/Node";
 export * from "./structures/Constants";
+export * from "./structures/Types/Manager";

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -13,3 +13,4 @@ export * from "./structures/Types/Player";
 export * from "./structures/Types/Queue";
 export * from "./structures/Types/Node";
 export * from "./structures/Constants";
+export * from "./structures/Types/Manager";

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -13,3 +13,4 @@ export * from "./structures/Types/Player";
 export * from "./structures/Types/Queue";
 export * from "./structures/Types/Node";
 export * from "./structures/Constants";
+export * from "./structures/Types/Manager";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export * from "./structures/Types/Player";
 export * from "./structures/Types/Queue";
 export * from "./structures/Types/Node";
 export * from "./structures/Constants";
+export * from "./structures/Types/Manager";


### PR DESCRIPTION
This fixes a problem importing types directly from the `lavalink-client` package.

![image](https://github.com/user-attachments/assets/6df42618-9367-45b2-a792-adc73c4a9086)