### PR TITLE
Fix getRequestingUrl() to pass back queue data.

### DIFF
--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -118,7 +118,7 @@ export class LavalinkNode {
      * ```
      */
     private getRequestingUrl(url: URL, extraQueryUrlParams?: URLSearchParams): string {
-        if (!url.searchParams.size) return `${url.origin}${url.pathname}`;
+        if (!url.searchParams.size) return `${url.origin}${url.pathname}${url.search}`;
         const keysToAdd = [];
         for (const [paramKey, paramValue] of url.searchParams.entries()) {
             const decoded = decodeURIComponent(paramValue).trim(); // double decoding, once internally, a second time if decoded by provided user.


### PR DESCRIPTION
# Explanation of the problem
I have been trying to figure out why my bot is broken when queuing tracks. Turns out when ``getRequestingUrl()`` parses the query but doesn't have any search parameters, it just deletes the original query data that was supposed to me sent to lavalink causing the most confusing set of issues I've dealt with. This was my solution that works for my bot.

## Before the patch
This is what would happen when you queued music on the latest lavalink-client patch before my fix, if the URL didn't have extra parameters.

![pre_Screenshot](https://github.com/user-attachments/assets/74b9d5fb-aebc-4d86-825a-8d283f21bbba)
The queue data would be lost.

## After the patch
![after_Screenshot](https://github.com/user-attachments/assets/99cb67f2-d62a-4f9a-912f-76a449019990)
The data is retained, and successfully queued.
