### PR TITLE
feat: save the voice payload in the player

### DIFF
--- a/src/structures/LavalinkManager.ts
+++ b/src/structures/LavalinkManager.ts
@@ -525,6 +525,13 @@ export class LavalinkManager extends EventEmitter {
                             }
                         }
                     });
+
+                    player.voice = {
+                        token: update.token,
+                        endpoint: update.endpoint,
+                        sessionId: sessionId2Use,
+                    }
+
                     if (this.options?.advancedOptions?.enableDebugEvents) {
                         this.emit("debug", DebugEvents.NoAudioDebug, {
                             state: "log",


### PR DESCRIPTION
This change saves the voice payload into the player, since the `voice` property of the player doesn't store the data.
This can  be useful in specific cases.