### PR TITLE
fix: update player options validation to allow single objects

### DIFF
--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -904,7 +904,7 @@ export class LavalinkNode {
      * @returns boolean
      */
     private syncPlayerData(data: Partial<PlayerUpdateInfo>, res?: LavalinkPlayer):void {
-        if (typeof data === "object" && typeof data?.guildId === "string" && typeof data.playerOptions === "object" && Object.keys(data.playerOptions).length > 1) {
+        if (typeof data === "object" && typeof data?.guildId === "string" && typeof data.playerOptions === "object" && Object.keys(data.playerOptions).length >= 1) {
             const player = this.NodeManager.LavalinkManager.getPlayer(data.guildId);
             if (!player) return;
 

--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -904,7 +904,7 @@ export class LavalinkNode {
      * @returns boolean
      */
     private syncPlayerData(data: Partial<PlayerUpdateInfo>, res?: LavalinkPlayer):void {
-        if (typeof data === "object" && typeof data?.guildId === "string" && typeof data.playerOptions === "object" && Object.keys(data.playerOptions).length >= 1) {
+        if (typeof data === "object" && typeof data?.guildId === "string" && typeof data.playerOptions === "object" && Object.keys(data.playerOptions).length > 0) {
             const player = this.NodeManager.LavalinkManager.getPlayer(data.guildId);
             if (!player) return;
 


### PR DESCRIPTION
After a some research, I found the issue which prevented the player's voice payload from being updated.

Internally, the player was updated with the payload but due to *that* small issue in the if statement, did not allow it to sync the data completely.

In the first instance, the payload was received but was never processed for allocation due to the check.

The proposed solution has been tested and is functional and does not affect other operations as it only allows paylods to be processed with a single key.