### PR TITLE
Fix: tries to reconnect to node when the node is deleted from nodeManager.nodes list

### DIFF
--- a/src/structures/Constants.ts
+++ b/src/structures/Constants.ts
@@ -61,6 +61,7 @@ export enum DestroyReasons {
     NodeReconnectFail = "NodeReconnectFail",
     Disconnected = "Disconnected",
     PlayerReconnectFail = "PlayerReconnectFail",
+    PlayerChangeNodeFail = "PlayerChangeNodeFail",
     ChannelDeleted = "ChannelDeleted",
     DisconnectAllNodes = "DisconnectAllNodes",
     ReconnectAllNodes = "ReconnectAllNodes",

--- a/src/structures/Constants.ts
+++ b/src/structures/Constants.ts
@@ -62,6 +62,7 @@ export enum DestroyReasons {
     Disconnected = "Disconnected",
     PlayerReconnectFail = "PlayerReconnectFail",
     PlayerChangeNodeFail = "PlayerChangeNodeFail",
+    PlayerChangeNodeFailNoEligibleNode = "PlayerChangeNodeFailNoEligibleNode",
     ChannelDeleted = "ChannelDeleted",
     DisconnectAllNodes = "DisconnectAllNodes",
     ReconnectAllNodes = "ReconnectAllNodes",

--- a/src/structures/NodeManager.ts
+++ b/src/structures/NodeManager.ts
@@ -189,6 +189,16 @@ export class NodeManager extends EventEmitter {
      * @param node The node to delete
      * @param movePlayers whether to movePlayers to different connected node before deletion. @default false
      * @returns
+     * 
+     * @example
+     * Deletes the node
+     * ```ts
+     * client.lavalink.nodeManager.deleteNode("nodeId to delete");
+     * ```
+     * Moves players to a different node before deleting
+     * ```ts
+     * client.lavalink.nodeManager.deleteNode("nodeId to delete", true);
+     * ```
      */
     deleteNode(node: LavalinkNodeIdentifier | LavalinkNode, movePlayers: boolean = false): void {
         const decodeNode = typeof node === "string" ? this.nodes.get(node) : node || this.leastUsedNodes()[0];

--- a/src/structures/NodeManager.ts
+++ b/src/structures/NodeManager.ts
@@ -187,12 +187,14 @@ export class NodeManager extends EventEmitter {
     /**
      * Delete a node from the nodeManager and destroy it
      * @param node The node to delete
+     * @param movePlayers whether to movePlayers to different connected node before deletion. @default false
      * @returns
      */
-    deleteNode(node: LavalinkNodeIdentifier | LavalinkNode): void {
+    deleteNode(node: LavalinkNodeIdentifier | LavalinkNode, movePlayers: boolean = false): void {
         const decodeNode = typeof node === "string" ? this.nodes.get(node) : node || this.leastUsedNodes()[0];
         if (!decodeNode) throw new Error("Node was not found");
-        decodeNode.destroy(DestroyReasons.NodeDeleted);
+        if (movePlayers) decodeNode.destroy(DestroyReasons.NodeDeleted, true, true);
+        else decodeNode.destroy(DestroyReasons.NodeDeleted);
         this.nodes.delete(decodeNode.id);
         return;
     }


### PR DESCRIPTION
Fix: clear unnecessary timers on nodeDelete.
Add: Before deleting any node now you Choose whether to move players to different node (lavalink.nodeManager.deleteNode() )