### PR TITLE
Remove queue.current on resolveError (fix resolving loop)

### DIFF
--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -296,6 +296,7 @@ export class Player {
 
                 if (typeof options.track?.userData === "object" && this.queue.current) this.queue.current.userData = { ...(this.queue.current?.userData || {}), ...(options.track?.userData || {}) };
             } catch (error) {
+
                 if (this.LavalinkManager.options?.advancedOptions?.enableDebugEvents) {
                     this.LavalinkManager.emit("debug", DebugEvents.PlayerPlayUnresolvedTrackFailed, {
                         state: "error",
@@ -310,9 +311,12 @@ export class Player {
                 if (options && "clientTrack" in options) delete options.clientTrack;
                 if (options && "track" in options) delete options.track;
 
+                // get rid of the current song without shifting the queue, so that the shifting can happen inside the next .play() call when "autoSkipOnResolveError" is true
+                await queueTrackEnd(this, true);
+
                 // try to play the next track if possible
                 if (this.LavalinkManager.options?.autoSkipOnResolveError === true && this.queue.tracks[0]) return this.play(options);
-
+                
                 return this;
             }
         }


### PR DESCRIPTION
When this.queue.current is an unresolved track (on rare occasions, cause normally it should be resolved on the shifting already), then if it fails to resolve, it leads in the catch, which automatically re-plays the song, but the current song doesnt get removed from queue, causing a loop of the resolving.

this does not happen with the options.clientTrack, as there its removed properly.

In the past this was handled through the trackError event, but i changed that event to not handle queue stuff anymore, cause lavalink sends both trackEnd and trackError when it errors from lavalink side. and we only send trackError when the described issue occurrs.