### PR TITLE
trying to fix deployments in forks

### DIFF
--- a/.github/workflows/deployDocs.yml
+++ b/.github/workflows/deployDocs.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'Tomato6966/lavalink-client'
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4

--- a/.github/workflows/publishAnyCommit.yml
+++ b/.github/workflows/publishAnyCommit.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository == 'Tomato6966/lavalink-client'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
For some reason, the publish any commit tries to publish the commit, this _~~I think~~_, is not necessary in a fork since the purpose of that workflow is only in the tomato's repo.