### PR TITLE
fix somes typings + added .DS_Store and bun.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ yarn.lock
 package-lock.json
 pnpm-lock.yaml
 dist
+*.DS_Store
+bun.lock

--- a/src/structures/Queue.ts
+++ b/src/structures/Queue.ts
@@ -98,7 +98,7 @@ export class DefaultQueueStore implements QueueStoreManager {
      * @param value The queue to stringify
      * @returns The stringified queue
      */
-    async stringify(value: StoredQueue) {
+    async stringify(value: StoredQueue | string): Promise<StoredQueue | string> {
         return value; // JSON.stringify(value);
     }
 
@@ -107,8 +107,8 @@ export class DefaultQueueStore implements QueueStoreManager {
      * @param value The queue to parse
      * @returns The parsed queue
      */
-    async parse(value: StoredQueue) {
-        return value; // JSON.parse(value)
+    async parse(value: StoredQueue | string): Promise<Partial<StoredQueue>> {
+        return value as Partial<StoredQueue>; // JSON.parse(value)
     }
 }
 


### PR DESCRIPTION
## Compilation with the latest packages version (with skipLibCheck in true)

```ts
node_modules/lavalink-client/dist/esm/structures/Queue.d.ts:68:5 - error TS2416: Property 'stringify' in type 'DefaultQueueStore' is not assignable to the same property in base type 'QueueStoreManager'.
  Type '(value: StoredQueue) => Promise<StoredQueue>' is not assignable to type '(value: string | StoredQueue) => Promise<string | StoredQueue>'.
    Types of parameters 'value' and 'value' are incompatible.
      Type 'string | StoredQueue' is not assignable to type 'StoredQueue'.
        Type 'string' is not assignable to type 'StoredQueue'.

68     stringify(value: StoredQueue): Promise<StoredQueue>;
       ~~~~~~~~~

node_modules/lavalink-client/dist/esm/structures/Queue.d.ts:74:5 - error TS2416: Property 'parse' in type 'DefaultQueueStore' is not assignable to the same property in base type 'QueueStoreManager'.
  Type '(value: StoredQueue) => Promise<StoredQueue>' is not assignable to type '(value: string | StoredQueue) => Promise<Partial<StoredQueue>>'.
    Types of parameters 'value' and 'value' are incompatible.
      Type 'string | StoredQueue' is not assignable to type 'StoredQueue'.
        Type 'string' is not assignable to type 'StoredQueue'.

74     parse(value: StoredQueue): Promise<StoredQueue>;
```

## Compilation after my changes:
```ts
[12:56:58 PM] Found 0 errors. Watching for file changes.
```

Cordially,
Anaïs Saraiva (Kisakay)