### PR TITLE
build: Migrate build to esbuild

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,41 @@
+const { build } = require('esbuild');
+const { rmSync } = require('fs');
+const path = require('path');
+
+
+rmSync(path.resolve('dist'), { recursive: true, force: true });
+
+const shared = {
+    entryPoints: ['src/index.ts'],
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    sourcemap: false,
+    minify: false,
+    splitting: false,
+    tsconfig: './tsconfig.json',
+};
+
+
+async function buildAll() {
+    try {
+        await Promise.all([
+            build({
+                ...shared,
+                format: 'cjs',
+                outdir: 'dist/cjs',
+            }),
+            build({
+                ...shared,
+                format: 'esm',
+                outdir: 'dist/esm',
+            }),
+        ]);
+        console.log('Build completed for CJS and ESM');
+    } catch (err) {
+        console.error('Build failed:', err);
+        process.exit(1);
+    }
+}
+
+buildAll();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,7 @@ export default [
             "**/testBot",
             "**/tools",
             "eslint.config.mjs",
+            "esbuild.config.js",
         ],
     },
     ...compat.extends("plugin:@typescript-eslint/recommended"),

--- a/package.json
+++ b/package.json
@@ -2,30 +2,27 @@
   "name": "lavalink-client",
   "version": "2.5.7",
   "description": "Easy, flexible and feature-rich lavalink@v4 Client. Both for Beginners and Proficients.",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
+    }
+  },
   "scripts": {
-    "build": "npm run tool:clean && npm run build:all && npm run tool:fixbuild",
-    "build:bun": "bun run tool:clean && bun run build:all:bun && bun run tool:fixbuild",
-    "build:all:bun": "bun run build:cjs && bun run build:esm && bun run build:types",
-    "build:all": "npm run build:cjs && npm run build:esm && npm run build:types",
-    "build:cjs": "tsc -p tools/config/tsconfig.cjs.json && tsc-alias -p tools/config/tsconfig.cjs.json",
-    "build:esm": "tsc -p tools/config/tsconfig.esm.json && tsc-alias -p tools/config/tsconfig.esm.json",
-    "build:types": "tsc -p tools/config/tsconfig.types.json && tsc-alias -p tools/config/tsconfig.types.json",
-    "tool:clean": "node tools/cleanup.js",
-    "tool:fixbuild": "node tools/fixup.js",
+    "build": "node esbuild.config.js && tsc -p tsconfig.build.json && tsc-alias",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "node -v",
     "prepublishOnly": "npm run build",
     "prepare": "npm run build"
   },
-  "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js",
-    "types": "./dist/types/index.d.js",
-    "default": "./dist/cjs/index.js"
+  "directories": {
+    "lib": "src"
   },
   "publishConfig": {
     "access": "public"
@@ -64,6 +61,7 @@
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
+    "esbuild": "^0.25.6",
     "eslint": "^9.27.0",
     "tsc-alias": "^1.8.16",
     "typescript": "^5.8.3"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "CommonJS",
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "./dist",
+        "declarationDir": "./dist",
+        "rootDir": "./src",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+    },
+    "include": [
+        "src"
+    ]
+}


### PR DESCRIPTION
This PR introduces `esbuild` for a more efficient and faster build process.

Key changes include:
- Added `esbuild.config.js` for `esbuild` specific configurations.
- Updated `package.json` scripts to utilize `esbuild` for building the project.

This change aims to improve build performance and streamline the development workflow.