### PR TITLE
Update dev dependencies and fix ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,7 @@ export default [
             "**/testBot",
             "**/tools",
             "eslint.config.mjs",
-            "tsup.comfig.mjs",
+            "tsup.config.mjs",
         ],
     },
     ...compat.extends("plugin:@typescript-eslint/recommended"),

--- a/package.json
+++ b/package.json
@@ -56,13 +56,12 @@
   "homepage": "https://tomato6966.github.io/lavalink-client/",
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
-    "@eslint/js": "^9.27.0",
-    "@types/node": "^24.0.11",
+    "@eslint/js": "^9.30.1",
+    "@types/node": "^24.0.13",
     "@types/ws": "^8.18.1",
-    "@typescript-eslint/eslint-plugin": "^8.32.1",
-    "@typescript-eslint/parser": "^8.32.1",
-    "eslint": "^9.27.0",
-    "tsc-alias": "^1.8.16",
+    "@typescript-eslint/eslint-plugin": "^8.36.0",
+    "@typescript-eslint/parser": "^8.36.0",
+    "eslint": "^9.30.1",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3"
   },


### PR DESCRIPTION
Upgrade ESLint, TypeScript, and related development dependencies to their latest versions. Correct a typo in `eslint.config.mjs` to properly ignore `tsup.config.mjs`. Remove `tsc-alias` from dev dependencies.