### PR TITLE
Refactor: circular references

### DIFF
--- a/src/structures/NodeManager.ts
+++ b/src/structures/NodeManager.ts
@@ -61,7 +61,7 @@ export class NodeManager extends EventEmitter {
     /**
      * The LavalinkManager that created this NodeManager
      */
-    public LavalinkManager: LavalinkManager;
+    private readonly LavalinkManager: LavalinkManager;
     /**
      * A map of all nodes in the nodeManager
      */

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -278,7 +278,7 @@ export class Player {
             });
         }
 
-        if (!this.queue.current && this.queue.tracks.length) await queueTrackEnd(this);
+        if (!this.queue.current && this.queue.tracks.length) await queueTrackEnd(this, false, this.LavalinkManager);
 
         if (this.queue.current && this.LavalinkManager.utils.isUnresolvedTrack(this.queue.current)) {
             if (this.LavalinkManager.options?.advancedOptions?.enableDebugEvents) {
@@ -315,7 +315,7 @@ export class Player {
                 if (options && "track" in options) delete options.track;
 
                 // get rid of the current song without shifting the queue, so that the shifting can happen inside the next .play() call when "autoSkipOnResolveError" is true
-                await queueTrackEnd(this, true);
+                await queueTrackEnd(this, true, this.LavalinkManager);
 
                 // try to play the next track if possible
                 if (this.LavalinkManager.options?.autoSkipOnResolveError === true && this.queue.tracks[0]) return this.play(options);


### PR DESCRIPTION
- Update `queueTrackEnd` and `getClosestTrack` to explicitly receive the `LavalinkManager` instance as an argument. This clarifies dependencies and makes the functions more standalone.
- Change the `LavalinkManager` property in `NodeManager` and `ManagerUtils` to `private readonly`. This enhances encapsulation and ensures the manager reference is immutable after initialization.

https://github.com/Tomato6966/lavalink-client/issues/53