### PR TITLE
feat: Add automatic player moving on node disconnect

### DIFF
--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -5,12 +5,12 @@ import { DebugEvents, DestroyReasons, validSponsorBlocks } from "./Constants";
 import { NodeSymbol, queueTrackEnd, safeStringify } from "./Utils";
 
 import type {
-	Base64, InvalidLavalinkRestRequest, LavalinkPlayer, LavaSearchQuery, LavaSearchResponse,
-	LoadTypes, LyricsFoundEvent, LyricsLineEvent, LyricsNotFoundEvent, PlayerEvents,
-	PlayerEventType, PlayerUpdateInfo, RoutePlanner, SearchQuery, SearchResult,
-	Session, SponsorBlockChaptersLoaded, SponsorBlockChapterStarted, SponsorBlockSegmentSkipped,
-	SponsorBlockSegmentsLoaded, TrackEndEvent, TrackExceptionEvent, TrackStartEvent,
-	TrackStuckEvent, WebSocketClosedEvent
+    Base64, InvalidLavalinkRestRequest, LavalinkPlayer, LavaSearchQuery, LavaSearchResponse,
+    LoadTypes, LyricsFoundEvent, LyricsLineEvent, LyricsNotFoundEvent, PlayerEvents,
+    PlayerEventType, PlayerUpdateInfo, RoutePlanner, SearchQuery, SearchResult,
+    Session, SponsorBlockChaptersLoaded, SponsorBlockChapterStarted, SponsorBlockSegmentSkipped,
+    SponsorBlockSegmentsLoaded, TrackEndEvent, TrackExceptionEvent, TrackStartEvent,
+    TrackStuckEvent, WebSocketClosedEvent
 } from "./Types/Utils";
 import type { Player } from "./Player";
 import type { DestroyReasonsType, DisconnectReasonsType } from "./Types/Player";
@@ -1121,6 +1121,17 @@ export class LavalinkNode {
                 this.reconnect();
             }
         }
+        
+        this.NodeManager.LavalinkManager.players
+            .filter((p) => p?.node?.options?.id === this?.options?.id)
+            .forEach((p) => {
+                if (!this.NodeManager.LavalinkManager.options.autoMove) return (p.playing = false);
+                if (this.NodeManager.LavalinkManager.options.autoMove) {
+                    if (this.NodeManager.nodes.filter((n) => n.connected).size === 0)
+                        return (p.playing = false);
+                    p.moveNode();
+                }
+            });
     }
 
     /** @private util function for handling error events from websocket */

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -843,6 +843,28 @@ export class Player {
         }
     }
 
+    /**
+     * Move the player to a different node. If no node is provided, it will find the least used node that is not the same as the current node.
+     * @param node the id of the node to move to
+     * @returns the player
+     * @throws RangeError if there is no available nodes.
+     * @throws Error if the node to move to is the same as the current node.
+     */
+    public async moveNode(node?: string) {
+        try {
+            if (!node) node = Array.from(this.LavalinkManager.nodeManager.leastUsedNodes("playingPlayers"))
+                .find(n => n.connected && n.options.id !== this.node.options.id).id;
+            if (!node || !this.LavalinkManager.nodeManager.nodes.get(node)) throw new RangeError("No nodes are available.");
+            if (this.node.options.id === node) return this;
+            this.LavalinkManager.emit("debug", DebugEvents.PlayerChangeNode, { state: "log", message: `Player.moveNode() was executed, trying to move from "${this.node.id}" to "${node}"`, functionLayer: "Player > moveNode()" });
+            const updateNode = this.LavalinkManager.nodeManager.nodes.get(node);
+            if (!updateNode) throw new RangeError("No nodes are available.");
+            return await this.changeNode(updateNode);
+        } catch (error) {
+            throw new Error(`Failed to move the node: ${error}`);
+        }
+    }
+    
     /** Converts the Player including Queue to a Json state */
     public toJSON() {
         return {

--- a/src/structures/Types/Manager.ts
+++ b/src/structures/Types/Manager.ts
@@ -258,6 +258,8 @@ export interface ManagerOptions {
     playerOptions?: ManagerPlayerOptions;
     /** If it should skip to the next Track on TrackEnd / TrackError etc. events */
     autoSkip?: boolean;
+    /** If it should automatically move the player to the next node when node is down */
+    autoMove?: boolean;
     /** If it should skip to the next Track if track.resolve errors while trying to play a track. */
     autoSkipOnResolveError?: boolean;
     /** If it should emit only new (unique) songs and not when a looping track (or similar) is plaid, default false */


### PR DESCRIPTION
This commit introduces a high-availability feature that automatically moves players to a new node when their current Lavalink node disconnects.

A new `autoMove` boolean option has been added to the `ManagerOptions` to control this behavior. When enabled, players associated with the disconnected node will be moved to the least-used available node. If no other nodes are available, the player's state is set to not playing.

Additionally, a new public method, `player.moveNode(nodeId?)`, is added to allow for manually moving a player to a specific node or the next best available one. This improves the resilience of the player, ensuring playback can continue even if a Lavalink node fails.