### PR TITLE
Update lavalink-youtube and add yt-cipher guide

### DIFF
--- a/docs/src/content/docs/home/setup-lavalink.mdx
+++ b/docs/src/content/docs/home/setup-lavalink.mdx
@@ -44,7 +44,7 @@ lavalink:
       repository: "https://maven.lavalink.dev/releases"
     - dependency: "com.github.devoxin:lavadspx-plugin:0.0.5" # https://github.com/devoxin/LavaDSPX-Plugin
       repository: "https://jitpack.io"
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.5" # https://github.com/lavalink-devs/youtube-source
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.14.0" # https://github.com/lavalink-devs/youtube-source
       snapshot: false
     - dependency: "com.github.topi314.lavalyrics:lavalyrics-plugin:1.0.0" # https://github.com/topi314/LavaLyrics
       repository: "https://maven.lavalink.dev/releases"
@@ -63,6 +63,11 @@ plugins:
       - yandexMusic
   youtube:
     enabled: true
+    # YouTube's cipher changes are becoming more frequent and complex, making it harder to keep up.
+    # To simplify signature deciphering, you can use a remote cipher server like yt-cipher, a lightweight Deno server with a REST API. More details are available at https://github.com/kikkia/yt-cipher
+    remoteCipher:
+      url: "http://localhost:8001" # The base URL of your remote cipher server.
+      password: "your_secret_password" # The password to authenticate with your remote cipher server.
     oauth:
       enabled: false
       # refreshToken: "Insert your refresh token here" # For more details, please refer to https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#using-oauth-tokens


### PR DESCRIPTION
This PR updates the lavalink-youtube source to the latest version and adds a yt-cipher guide to setup-lavalink.md