### PR TITLE
fix: error from typo in play.ts

### DIFF
--- a/testBot/commands/play.ts
+++ b/testBot/commands/play.ts
@@ -59,8 +59,6 @@ export default {
             // vcRegion: (interaction.member as GuildMember)?.voice.channel?.rtcRegion!
         });
 
-        player.npMessage
-
         const connected = player.connected;
 
         if (!connected) await player.connect();


### PR DESCRIPTION
First commit fixes the following error when running the testBot:

/opt/app/testBot/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
Utils/CustomClasses/customPlayerClass.ts(14,14): error TS2339: Property 'npMess' does not exist on type 'myCustomPlayer'.

Second commit removes the line entirely as it accesses the property but does nothing with it.