### PR TITLE
fix: not reconnecting after 1st error

### DIFF
--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -485,6 +485,7 @@ export class LavalinkNode {
      */
     public destroy(destroyReason?: DestroyReasonsType, deleteNode: boolean = true, movePlayers: boolean = false): void {
         // if (!this.connected) return; This Prevents the node from being destroyed if it is not connected, but we want to allow it to be destroyed even if not connected.
+        this.reconnectionState = ReconnectionState.IDLE;
 
         const players = this.NodeManager.LavalinkManager.players.filter(p => p.node.id === this.id);
         if (players.size) {
@@ -581,6 +582,7 @@ export class LavalinkNode {
         this.socket?.close(1000, "Node-Disconnect");
         this.socket?.removeAllListeners();
         this.socket = null;
+        this.reconnectionState = ReconnectionState.IDLE;
 
         this.resetReconnectionAttempts();
 
@@ -1182,6 +1184,7 @@ export class LavalinkNode {
     private error(error: Error): void {
         if (!error) return;
         this.NodeManager.emit("error", this, error);
+        this.reconnectionState = ReconnectionState.IDLE;
         this.reconnect();
         if (this.options.closeOnError) {
             if (this.heartBeatInterval) clearInterval(this.heartBeatInterval);
@@ -1770,3 +1773,4 @@ export class LavalinkNode {
         return;
     }
 }
+


### PR DESCRIPTION
This pull request makes several improvements to the lifecycle management of the `LavalinkNode` class, focusing on ensuring the node's reconnection state is properly reset in key scenarios. This helps prevent unintended reconnection attempts and improves stability when nodes are destroyed, disconnected, or encounter errors.

Lifecycle and reconnection state management:

* Set `reconnectionState` to `ReconnectionState.IDLE` at the start of the `destroy` method to ensure the node does not attempt to reconnect during or after destruction.
* Reset `reconnectionState` to `IDLE` after closing the socket and removing listeners in the disconnect logic, further preventing unwanted reconnection attempts.
* Set `reconnectionState` to `IDLE` in the error handler before attempting to reconnect, ensuring a clean reconnection process and avoiding stale state issues.