### PR TITLE
fix: make auto node migration reliable

### DIFF
--- a/src/structures/LavalinkManager.ts
+++ b/src/structures/LavalinkManager.ts
@@ -153,6 +153,11 @@ export class LavalinkManager<CustomPlayerT extends Player = Player> extends Even
             advancedOptions: {
                 enableDebugEvents: options?.advancedOptions?.enableDebugEvents ?? false,
                 maxFilterFixDuration: options?.advancedOptions?.maxFilterFixDuration ?? 600_000,
+                playerMigration: {
+                    concurrency: options?.advancedOptions?.playerMigration?.concurrency ?? 5,
+                    perTargetConcurrency: options?.advancedOptions?.playerMigration?.perTargetConcurrency ?? 2,
+                    backpressureDelayMs: options?.advancedOptions?.playerMigration?.backpressureDelayMs ?? 50,
+                },
                 debugOptions: {
                     logCustomSearches: options?.advancedOptions?.debugOptions?.logCustomSearches ?? false,
                     noAudio: options?.advancedOptions?.debugOptions?.noAudio ?? false,

--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -658,7 +658,11 @@ export class LavalinkNode {
             { headers },
         );
         this.socket.on("open", this.open.bind(this));
-        this.socket.on("close", (code, reason) => this.close(code, reason?.toString()));
+        this.socket.on("close", (code, reason) =>
+            void this.close(code, reason?.toString()).catch((error) => {
+                this.NodeManager.emit("error", this, error as Error);
+            }),
+        );
         this.socket.on("message", this.message.bind(this));
         this.socket.on("error", this.error.bind(this));
         // this.socket.on("ping", () => this.heartBeat("ping")); // lavalink doesn'T send ping periodically, therefore we use the stats message
@@ -764,46 +768,7 @@ export class LavalinkNode {
                     ),
                 );
             }
-            const nodeToMove = Array.from(this.NodeManager.leastUsedNodes("playingPlayers")).find(
-                (n) => n.connected && n.options.id !== this.id,
-            );
-
-            if (!nodeToMove) {
-                return Promise.allSettled(
-                    Array.from(players.values()).map((player) =>
-                        player.destroy(DestroyReasons.PlayerChangeNodeFailNoEligibleNode).catch((error) => {
-                            this._emitDebugEvent(DebugEvents.PlayerChangeNodeFailNoEligibleNode, {
-                                state: "error",
-                                message: `Failed to destroy player ${player.guildId}: ${error.message}`,
-                                error,
-                                functionLayer: "Node > destroy() > movePlayers",
-                            });
-                        }),
-                    ),
-                );
-            }
-            return Promise.allSettled(
-                Array.from(players.values()).map((player) =>
-                    player.changeNode(nodeToMove.options.id).catch((error) => {
-                        this._emitDebugEvent(DebugEvents.PlayerChangeNodeFail, {
-                            state: "error",
-                            message: `Failed to move player ${player.guildId}: ${error.message}`,
-                            error,
-                            functionLayer: "Node > destroy() > movePlayers",
-                        });
-                        return player
-                            .destroy(error.message ?? DestroyReasons.PlayerChangeNodeFail)
-                            .catch((destroyError) => {
-                                this._emitDebugEvent(DebugEvents.PlayerDestroyFail, {
-                                    state: "error",
-                                    message: `Failed to destroy player ${player.guildId} after move failure: ${destroyError.message}`,
-                                    error: destroyError,
-                                    functionLayer: "Node > destroy() > movePlayers",
-                                });
-                            });
-                    }),
-                ),
-            );
+            return this.movePlayersToReplacementNode(Array.from(players.values()), "destroy");
         };
 
         // Handle all player operations first, then clean up the socket
@@ -848,6 +813,75 @@ export class LavalinkNode {
         this.resetReconnectionAttempts();
 
         this.NodeManager.emit("disconnect", this, { code: 1000, reason: disconnectReason });
+    }
+
+    /**
+     * Pick the best ready node to move players to.
+     * A node must be connected and have a sessionId before a player can be migrated to it.
+     */
+    private getReadyMigrationNode(excludeNodeId: string): LavalinkNode | NodeLinkNode | null {
+        return (
+            Array.from(this.NodeManager.leastUsedNodes("playingPlayers")).find(
+                (node) => node.connected && !!node.sessionId && node.options.id !== excludeNodeId,
+            ) || null
+        );
+    }
+
+    /**
+     * Move a batch of players to a ready node sequentially.
+     * Sequential migration avoids bursty REST timeouts and keeps voice snapshots alive per player.
+     */
+    private async movePlayersToReplacementNode(
+        players: Player[],
+        onNoEligibleNode: "destroy" | "freeze",
+    ): Promise<void> {
+        for (const player of players) {
+            const targetNode = this.getReadyMigrationNode(player.node?.options?.id || this.id);
+
+            if (!targetNode) {
+                if (onNoEligibleNode === "destroy") {
+                    await player.destroy(DestroyReasons.PlayerChangeNodeFailNoEligibleNode).catch((error) => {
+                        this._emitDebugEvent(DebugEvents.PlayerChangeNodeFailNoEligibleNode, {
+                            state: "error",
+                            message: `Failed to destroy player ${player.guildId}: ${error.message}`,
+                            error,
+                            functionLayer: "Node > movePlayersToReplacementNode()",
+                        });
+                    });
+                } else {
+                    player.playing = false;
+                }
+                continue;
+            }
+
+            player.setData("internal_nodeMoveVoiceData", { ...player.voice });
+
+            try {
+                await player.changeNode(targetNode.id);
+            } catch (error) {
+                this._emitDebugEvent(DebugEvents.PlayerChangeNodeFail, {
+                    state: "error",
+                    message: `Failed to move player ${player.guildId}: ${error.message}`,
+                    error,
+                    functionLayer: "Node > movePlayersToReplacementNode()",
+                });
+
+                if (onNoEligibleNode === "destroy") {
+                    await player.destroy(error.message ?? DestroyReasons.PlayerChangeNodeFail).catch((destroyError) => {
+                        this._emitDebugEvent(DebugEvents.PlayerDestroyFail, {
+                            state: "error",
+                            message: `Failed to destroy player ${player.guildId} after move failure: ${destroyError.message}`,
+                            error: destroyError,
+                            functionLayer: "Node > movePlayersToReplacementNode()",
+                        });
+                    });
+                } else {
+                    player.playing = false;
+                }
+            } finally {
+                player.setData("internal_nodeMoveVoiceData", undefined);
+            }
+        }
     }
 
     /**
@@ -1738,7 +1772,7 @@ export class LavalinkNode {
     }
 
     /** @private util function for handling closing events from websocket */
-    private close(code: number, reason: string): void {
+    private async close(code: number, reason: string): Promise<void> {
         this.resetAckTimeouts(true, true);
 
         try {
@@ -1761,6 +1795,16 @@ export class LavalinkNode {
         if (code === 1006 && !reason) reason = "Socket got terminated due to no ping connection";
         if (code === 1000 && reason === "Node-Disconnect") return; // manually disconnected and already emitted the event.
 
+        const players = Array.from(this._LManager.players.filter((p) => p?.node?.options?.id === this?.options?.id).values());
+
+        if (this._LManager.options.autoMove && players.length) {
+            await this.movePlayersToReplacementNode(players, "freeze");
+        } else if (!this._LManager.options.autoMove) {
+            players.forEach((p) => (p.playing = false));
+        } else if (this.NodeManager.nodes.filter((n) => n.connected && !!n.sessionId).size === 0) {
+            players.forEach((p) => (p.playing = false));
+        }
+
         this.NodeManager.emit("disconnect", this, { code, reason });
 
         if (code !== 1000 || reason !== "Node-Destroy") {
@@ -1769,16 +1813,6 @@ export class LavalinkNode {
                 this.reconnect();
             }
         }
-
-        this._LManager.players
-            .filter((p) => p?.node?.options?.id === this?.options?.id)
-            .forEach((p) => {
-                if (!this._LManager.options.autoMove) return (p.playing = false);
-                if (this._LManager.options.autoMove) {
-                    if (this.NodeManager.nodes.filter((n) => n.connected).size === 0) return (p.playing = false);
-                    p.moveNode();
-                }
-            });
     }
 
     /** @private util function for handling error events from websocket */

--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -65,6 +65,19 @@ import type {
     WebSocketClosedEvent,
 } from "./Types/Utils";
 import { NodeSymbol, queueTrackEnd, safeStringify } from "./Utils";
+
+const migrationReservations = new Map<string, number>();
+const migrationCapacityWaiters = new Set<() => void>();
+
+const signalMigrationCapacityChange = () => {
+    for (const resolve of migrationCapacityWaiters) resolve();
+    migrationCapacityWaiters.clear();
+};
+const normalizeInt = (value: unknown, fallback: number, min: number, max: number) => {
+    const parsed = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.min(max, Math.max(min, Math.floor(parsed)));
+};
 /**
  * Lavalink Node creator class
  */
@@ -658,10 +671,12 @@ export class LavalinkNode {
             { headers },
         );
         this.socket.on("open", this.open.bind(this));
-        this.socket.on("close", (code, reason) =>
-            void this.close(code, reason?.toString()).catch((error) => {
-                this.NodeManager.emit("error", this, error as Error);
-            }),
+        this.socket.on(
+            "close",
+            (code, reason) =>
+                void this.close(code, reason?.toString()).catch((error) => {
+                    this.NodeManager.emit("error", this, error as Error);
+                }),
         );
         this.socket.on("message", this.message.bind(this));
         this.socket.on("error", this.error.bind(this));
@@ -820,57 +835,257 @@ export class LavalinkNode {
      * A node must be connected and have a sessionId before a player can be migrated to it.
      */
     private getReadyMigrationNode(excludeNodeId: string): LavalinkNode | NodeLinkNode | null {
-        return (
-            Array.from(this.NodeManager.leastUsedNodes("playingPlayers")).find(
-                (node) => node.connected && !!node.sessionId && node.options.id !== excludeNodeId,
-            ) || null
-        );
+        return this.selectMigrationTarget(new Set([excludeNodeId]), Number.MAX_SAFE_INTEGER);
+    }
+
+    private getMigrationErrorMessage(error: unknown): string {
+        if (error instanceof Error) return error.message;
+        if (typeof error === "string") return error;
+        try {
+            return safeStringify(error);
+        } catch {
+            return String(error);
+        }
+    }
+
+    private getMigrationConfig() {
+        const migration = this._LManager.options?.advancedOptions?.playerMigration;
+        return {
+            concurrency: normalizeInt(migration?.concurrency, 5, 1, 32),
+            perTargetConcurrency: normalizeInt(migration?.perTargetConcurrency, 2, 1, 8),
+            backpressureDelayMs: normalizeInt(migration?.backpressureDelayMs, 50, 0, 1000),
+        };
+    }
+
+    private getMigrationReservationCount(nodeId: string): number {
+        return migrationReservations.get(nodeId) || 0;
+    }
+
+    private reserveMigrationTarget(nodeId: string): void {
+        migrationReservations.set(nodeId, this.getMigrationReservationCount(nodeId) + 1);
+    }
+
+    private releaseMigrationTarget(nodeId: string): void {
+        const current = this.getMigrationReservationCount(nodeId);
+        if (current <= 1) migrationReservations.delete(nodeId);
+        else migrationReservations.set(nodeId, current - 1);
+        signalMigrationCapacityChange();
+    }
+
+    private getEffectiveMigrationLoad(node: LavalinkNode | NodeLinkNode): number {
+        return (node.stats?.players || 0) + this.getMigrationReservationCount(node.id);
+    }
+
+    private selectMigrationTarget(
+        excludeNodeIds: Set<string>,
+        perTargetConcurrency: number,
+    ): LavalinkNode | NodeLinkNode | null {
+        let selectedNode: LavalinkNode | NodeLinkNode | null = null;
+        let selectedEffectiveLoad = Number.POSITIVE_INFINITY;
+        let selectedLiveLoad = Number.POSITIVE_INFINITY;
+
+        for (const node of this.NodeManager.nodes.values()) {
+            if (!node.connected || !node.sessionId) continue;
+            if (excludeNodeIds.has(node.id)) continue;
+
+            const reservationCount = this.getMigrationReservationCount(node.id);
+            if (reservationCount >= perTargetConcurrency) continue;
+
+            const liveLoad = node.stats?.players || 0;
+            const effectiveLoad = this.getEffectiveMigrationLoad(node);
+
+            if (
+                !selectedNode ||
+                effectiveLoad < selectedEffectiveLoad ||
+                (effectiveLoad === selectedEffectiveLoad &&
+                    (liveLoad < selectedLiveLoad ||
+                        (liveLoad === selectedLiveLoad && node.id.localeCompare(selectedNode.id) < 0)))
+            ) {
+                selectedNode = node;
+                selectedEffectiveLoad = effectiveLoad;
+                selectedLiveLoad = liveLoad;
+            }
+        }
+
+        return selectedNode;
+    }
+
+    private hasAnyHealthyMigrationNode(excludeNodeIds: Set<string>): boolean {
+        for (const node of this.NodeManager.nodes.values()) {
+            if (!node.connected || !node.sessionId) continue;
+            if (excludeNodeIds.has(node.id)) continue;
+            return true;
+        }
+        return false;
+    }
+
+    private isMigrationNodeHealthy(nodeId: string): boolean {
+        const node = this.NodeManager.nodes.get(nodeId);
+        return !!node?.connected && !!node.sessionId;
+    }
+
+    private async waitForMigrationCapacity(
+        excludeNodeIds: Set<string>,
+        perTargetConcurrency: number,
+        timeoutMs: number,
+    ): Promise<void> {
+        if (this.selectMigrationTarget(excludeNodeIds, perTargetConcurrency)) return;
+
+        if (timeoutMs <= 0) {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            return;
+        }
+
+        await new Promise<void>((resolve) => {
+            let settled = false;
+            let timer: NodeJS.Timeout | undefined;
+            const onSignal = () => {
+                if (settled) return;
+                settled = true;
+                if (timer) clearTimeout(timer);
+                migrationCapacityWaiters.delete(onSignal);
+                resolve();
+            };
+
+            timer = setTimeout(() => {
+                if (settled) return;
+                settled = true;
+                migrationCapacityWaiters.delete(onSignal);
+                resolve();
+            }, timeoutMs);
+
+            migrationCapacityWaiters.add(onSignal);
+        });
     }
 
     /**
-     * Move a batch of players to a ready node sequentially.
-     * Sequential migration avoids bursty REST timeouts and keeps voice snapshots alive per player.
+     * Move a batch of players to a ready node with bounded concurrency.
+     * This keeps migration responsive without flooding the replacement node with requests.
      */
     private async movePlayersToReplacementNode(
         players: Player[],
         onNoEligibleNode: "destroy" | "freeze",
     ): Promise<void> {
-        for (const player of players) {
-            const targetNode = this.getReadyMigrationNode(player.node?.options?.id || this.id);
+        const migrationQueue = players.filter((player) => {
+            if (player.getData("internal_nodeMigrating") === true) return false;
+            if (player.getData("internal_destroystatus") === true) return false;
+            player.setData("internal_nodeMigrating", true);
+            return true;
+        });
+        const { concurrency, perTargetConcurrency, backpressureDelayMs } = this.getMigrationConfig();
+        let nextQueueIndex = 0;
+        const workerCount = Math.min(concurrency, migrationQueue.length);
 
-            if (!targetNode) {
-                if (onNoEligibleNode === "destroy") {
-                    await player.destroy(DestroyReasons.PlayerChangeNodeFailNoEligibleNode).catch((error) => {
-                        this._emitDebugEvent(DebugEvents.PlayerChangeNodeFailNoEligibleNode, {
+        const migratePlayer = async (player: Player): Promise<void> => {
+            const excludedNodes = new Set<string>();
+
+            try {
+                for (let attempt = 0; attempt < 2; attempt++) {
+                    if (player.getData("internal_destroystatus") === true) return;
+                    if (player.node?.options?.id !== this.id) return;
+
+                    let targetNode: LavalinkNode | NodeLinkNode | null = null;
+
+                    while (!(targetNode = this.selectMigrationTarget(excludedNodes, perTargetConcurrency))) {
+                        if (!this.hasAnyHealthyMigrationNode(excludedNodes)) {
+                            this._emitDebugEvent(DebugEvents.PlayerChangeNodeFailNoEligibleNode, {
+                                state: "warn",
+                                message: `No eligible ready node was available for player ${player.guildId}`,
+                                functionLayer: "Node > movePlayersToReplacementNode()",
+                            });
+
+                            if (onNoEligibleNode === "destroy") {
+                                await player
+                                    .destroy(DestroyReasons.PlayerChangeNodeFailNoEligibleNode)
+                                    .catch((destroyError) => {
+                                        this._emitDebugEvent(DebugEvents.PlayerDestroyFail, {
+                                            state: "error",
+                                            message: `Failed to destroy player ${player.guildId}: ${this.getMigrationErrorMessage(destroyError)}`,
+                                            error: destroyError,
+                                            functionLayer: "Node > movePlayersToReplacementNode()",
+                                        });
+                                    });
+                            } else {
+                                player.playing = false;
+                            }
+                            return;
+                        }
+
+                        await this.waitForMigrationCapacity(excludedNodes, perTargetConcurrency, backpressureDelayMs);
+                    }
+
+                    const targetNodeId = targetNode.id;
+                    if (player.getData("internal_destroystatus") === true) return;
+                    if (player.node?.options?.id !== this.id) return;
+                    this.reserveMigrationTarget(targetNodeId);
+                    player.setData("internal_nodeMoveVoiceData", { ...player.voice });
+
+                    try {
+                        await player.changeNode(targetNodeId);
+                        return;
+                    } catch (error) {
+                        const errorMessage = this.getMigrationErrorMessage(error);
+                        this._emitDebugEvent(DebugEvents.PlayerChangeNodeFail, {
                             state: "error",
-                            message: `Failed to destroy player ${player.guildId}: ${error.message}`,
+                            message: `Failed to move player ${player.guildId}: ${errorMessage}`,
                             error,
                             functionLayer: "Node > movePlayersToReplacementNode()",
                         });
-                    });
-                } else {
-                    player.playing = false;
+
+                        const targetStillHealthy = this.isMigrationNodeHealthy(targetNodeId);
+                        excludedNodes.add(targetNodeId);
+
+                        if (attempt === 0 && !targetStillHealthy) {
+                            this._emitDebugEvent(DebugEvents.PlayerChangeNodeFail, {
+                                state: "warn",
+                                message: `Migration target ${targetNodeId} became unavailable while moving player ${player.guildId}; retrying on another ready node`,
+                                error,
+                                functionLayer: "Node > movePlayersToReplacementNode()",
+                            });
+                            continue;
+                        }
+
+                        if (attempt === 0 && this.hasAnyHealthyMigrationNode(excludedNodes)) {
+                            this._emitDebugEvent(DebugEvents.PlayerChangeNodeFail, {
+                                state: "warn",
+                                message: `Retrying migration for player ${player.guildId} on a different ready node`,
+                                error,
+                                functionLayer: "Node > movePlayersToReplacementNode()",
+                            });
+                            continue;
+                        }
+
+                        if (onNoEligibleNode === "destroy") {
+                            await player.destroy(DestroyReasons.PlayerChangeNodeFail).catch((destroyError) => {
+                                this._emitDebugEvent(DebugEvents.PlayerDestroyFail, {
+                                    state: "error",
+                                    message: `Failed to destroy player ${player.guildId} after unexpected migration failure: ${this.getMigrationErrorMessage(destroyError)}`,
+                                    error: destroyError,
+                                    functionLayer: "Node > movePlayersToReplacementNode()",
+                                });
+                            });
+                        } else {
+                            player.playing = false;
+                        }
+                        return;
+                    } finally {
+                        player.setData("internal_nodeMoveVoiceData", undefined);
+                        this.releaseMigrationTarget(targetNodeId);
+                    }
                 }
-                continue;
-            }
-
-            player.setData("internal_nodeMoveVoiceData", { ...player.voice });
-
-            try {
-                await player.changeNode(targetNode.id);
             } catch (error) {
                 this._emitDebugEvent(DebugEvents.PlayerChangeNodeFail, {
                     state: "error",
-                    message: `Failed to move player ${player.guildId}: ${error.message}`,
+                    message: `Unexpected error while migrating player ${player.guildId}: ${this.getMigrationErrorMessage(error)}`,
                     error,
                     functionLayer: "Node > movePlayersToReplacementNode()",
                 });
 
                 if (onNoEligibleNode === "destroy") {
-                    await player.destroy(error.message ?? DestroyReasons.PlayerChangeNodeFail).catch((destroyError) => {
+                    await player.destroy(DestroyReasons.PlayerChangeNodeFail).catch((destroyError) => {
                         this._emitDebugEvent(DebugEvents.PlayerDestroyFail, {
                             state: "error",
-                            message: `Failed to destroy player ${player.guildId} after move failure: ${destroyError.message}`,
+                            message: `Failed to destroy player ${player.guildId} after unexpected migration failure: ${this.getMigrationErrorMessage(destroyError)}`,
                             error: destroyError,
                             functionLayer: "Node > movePlayersToReplacementNode()",
                         });
@@ -878,10 +1093,39 @@ export class LavalinkNode {
                 } else {
                     player.playing = false;
                 }
-            } finally {
-                player.setData("internal_nodeMoveVoiceData", undefined);
             }
-        }
+        };
+
+        const workers = Array.from({ length: workerCount }, async () => {
+            while (true) {
+                const queueIndex = nextQueueIndex++;
+                if (queueIndex >= migrationQueue.length) return;
+
+                const player = migrationQueue[queueIndex];
+                if (!player) continue;
+
+                try {
+                    if (player.getData("internal_nodeMigrating") !== true) {
+                        player.setData("internal_nodeMigrating", true);
+                    }
+                    if (player.getData("internal_destroystatus") === true) continue;
+                    if (player.node?.options?.id !== this.id) continue;
+                    await migratePlayer(player);
+                } catch (error) {
+                    this._emitDebugEvent(DebugEvents.PlayerChangeNodeFail, {
+                        state: "error",
+                        message: `Unexpected worker error while migrating player ${player.guildId}: ${this.getMigrationErrorMessage(error)}`,
+                        error,
+                        functionLayer: "Node > movePlayersToReplacementNode()",
+                    });
+                } finally {
+                    player.setData("internal_nodeMigrating", undefined);
+                    player.setData("internal_nodeMoveVoiceData", undefined);
+                }
+            }
+        });
+
+        await Promise.all(workers);
     }
 
     /**
@@ -1769,6 +2013,7 @@ export class LavalinkNode {
         this.info.isNodelink = !!this.info.isNodelink;
 
         this.NodeManager.emit("connect", this);
+        signalMigrationCapacityChange();
     }
 
     /** @private util function for handling closing events from websocket */
@@ -1795,7 +2040,9 @@ export class LavalinkNode {
         if (code === 1006 && !reason) reason = "Socket got terminated due to no ping connection";
         if (code === 1000 && reason === "Node-Disconnect") return; // manually disconnected and already emitted the event.
 
-        const players = Array.from(this._LManager.players.filter((p) => p?.node?.options?.id === this?.options?.id).values());
+        const players = Array.from(
+            this._LManager.players.filter((p) => p?.node?.options?.id === this?.options?.id).values(),
+        );
 
         if (this._LManager.options.autoMove && players.length) {
             await this.movePlayersToReplacementNode(players, "freeze");

--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -66,13 +66,6 @@ import type {
 } from "./Types/Utils";
 import { NodeSymbol, queueTrackEnd, safeStringify } from "./Utils";
 
-const migrationReservations = new Map<string, number>();
-const migrationCapacityWaiters = new Set<() => void>();
-
-const signalMigrationCapacityChange = () => {
-    for (const resolve of migrationCapacityWaiters) resolve();
-    migrationCapacityWaiters.clear();
-};
 const normalizeInt = (value: unknown, fallback: number, min: number, max: number) => {
     const parsed = typeof value === "number" ? value : Number(value);
     if (!Number.isFinite(parsed)) return fallback;
@@ -858,18 +851,18 @@ export class LavalinkNode {
     }
 
     private getMigrationReservationCount(nodeId: string): number {
-        return migrationReservations.get(nodeId) || 0;
+        return this.NodeManager.playerMigration.reservations.get(nodeId) || 0;
     }
 
     private reserveMigrationTarget(nodeId: string): void {
-        migrationReservations.set(nodeId, this.getMigrationReservationCount(nodeId) + 1);
+        this.NodeManager.playerMigration.reservations.set(nodeId, this.getMigrationReservationCount(nodeId) + 1);
     }
 
     private releaseMigrationTarget(nodeId: string): void {
         const current = this.getMigrationReservationCount(nodeId);
-        if (current <= 1) migrationReservations.delete(nodeId);
-        else migrationReservations.set(nodeId, current - 1);
-        signalMigrationCapacityChange();
+        if (current <= 1) this.NodeManager.playerMigration.reservations.delete(nodeId);
+        else this.NodeManager.playerMigration.reservations.set(nodeId, current - 1);
+        this.NodeManager.signalPlayerMigrationCapacityChange();
     }
 
     private getEffectiveMigrationLoad(node: LavalinkNode | NodeLinkNode): number {
@@ -943,18 +936,18 @@ export class LavalinkNode {
                 if (settled) return;
                 settled = true;
                 if (timer) clearTimeout(timer);
-                migrationCapacityWaiters.delete(onSignal);
+                this.NodeManager.playerMigration.capacityWaiters.delete(onSignal);
                 resolve();
             };
 
             timer = setTimeout(() => {
                 if (settled) return;
                 settled = true;
-                migrationCapacityWaiters.delete(onSignal);
+                this.NodeManager.playerMigration.capacityWaiters.delete(onSignal);
                 resolve();
             }, timeoutMs);
 
-            migrationCapacityWaiters.add(onSignal);
+            this.NodeManager.playerMigration.capacityWaiters.add(onSignal);
         });
     }
 
@@ -1042,6 +1035,7 @@ export class LavalinkNode {
                                 error,
                                 functionLayer: "Node > movePlayersToReplacementNode()",
                             });
+                            if (player.node?.options?.id === targetNodeId) player.node = this;
                             continue;
                         }
 
@@ -1052,6 +1046,7 @@ export class LavalinkNode {
                                 error,
                                 functionLayer: "Node > movePlayersToReplacementNode()",
                             });
+                            if (player.node?.options?.id === targetNodeId) player.node = this;
                             continue;
                         }
 
@@ -2013,7 +2008,7 @@ export class LavalinkNode {
         this.info.isNodelink = !!this.info.isNodelink;
 
         this.NodeManager.emit("connect", this);
-        signalMigrationCapacityChange();
+        this.NodeManager.signalPlayerMigrationCapacityChange();
     }
 
     /** @private util function for handling closing events from websocket */
@@ -2044,14 +2039,6 @@ export class LavalinkNode {
             this._LManager.players.filter((p) => p?.node?.options?.id === this?.options?.id).values(),
         );
 
-        if (this._LManager.options.autoMove && players.length) {
-            await this.movePlayersToReplacementNode(players, "freeze");
-        } else if (!this._LManager.options.autoMove) {
-            players.forEach((p) => (p.playing = false));
-        } else if (this.NodeManager.nodes.filter((n) => n.connected && !!n.sessionId).size === 0) {
-            players.forEach((p) => (p.playing = false));
-        }
-
         this.NodeManager.emit("disconnect", this, { code, reason });
 
         if (code !== 1000 || reason !== "Node-Destroy") {
@@ -2059,6 +2046,14 @@ export class LavalinkNode {
                 // try to reconnect only when the node is still in the nodeManager.nodes list
                 this.reconnect();
             }
+        }
+
+        if (this._LManager.options.autoMove && players.length) {
+            await this.movePlayersToReplacementNode(players, "freeze");
+        } else if (!this._LManager.options.autoMove) {
+            players.forEach((p) => (p.playing = false));
+        } else if (this.NodeManager.nodes.filter((n) => n.connected && !!n.sessionId).size === 0) {
+            players.forEach((p) => (p.playing = false));
         }
     }
 

--- a/src/structures/Node.ts
+++ b/src/structures/Node.ts
@@ -1011,7 +1011,6 @@ export class LavalinkNode {
                     if (player.getData("internal_destroystatus") === true) return;
                     if (player.node?.options?.id !== this.id) return;
                     this.reserveMigrationTarget(targetNodeId);
-                    player.setData("internal_nodeMoveVoiceData", { ...player.voice });
 
                     try {
                         await player.changeNode(targetNodeId);
@@ -1064,7 +1063,6 @@ export class LavalinkNode {
                         }
                         return;
                     } finally {
-                        player.setData("internal_nodeMoveVoiceData", undefined);
                         this.releaseMigrationTarget(targetNodeId);
                     }
                 }
@@ -1115,7 +1113,6 @@ export class LavalinkNode {
                     });
                 } finally {
                     player.setData("internal_nodeMigrating", undefined);
-                    player.setData("internal_nodeMoveVoiceData", undefined);
                 }
             }
         });

--- a/src/structures/NodeManager.ts
+++ b/src/structures/NodeManager.ts
@@ -66,6 +66,17 @@ export class NodeManager extends EventEmitter {
      * A map of all nodes in the nodeManager
      */
     public nodes = new MiniMap<string, LavalinkNode | NodeLinkNode>();
+    /** @internal Coordinates player migrations between nodes owned by this manager. */
+    public readonly playerMigration = {
+        reservations: new Map<string, number>(),
+        capacityWaiters: new Set<() => void>(),
+    };
+
+    /** @internal Wakes migrations waiting for capacity on one of this manager's nodes. */
+    public signalPlayerMigrationCapacityChange(): void {
+        for (const resolve of this.playerMigration.capacityWaiters) resolve();
+        this.playerMigration.capacityWaiters.clear();
+    }
 
     /**
      * @param LavalinkManager The LavalinkManager that created this NodeManager

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -992,8 +992,7 @@ export class Player {
         const data = this.toJSON();
         const currentTrack = this.queue.current;
         const storedVoice = this.getData<LavalinkPlayerVoiceOptions | undefined>("internal_nodeMoveVoiceData");
-        const voiceData =
-            this.voice?.endpoint && this.voice?.sessionId && this.voice?.token ? this.voice : storedVoice;
+        const voiceData = this.voice?.endpoint && this.voice?.sessionId && this.voice?.token ? this.voice : storedVoice;
         if (!voiceData?.endpoint || !voiceData?.sessionId || !voiceData?.token)
             throw new Error("Voice Data is missing, can't change the node");
         this.setData("internal_nodeChanging", true); // This will stop execution of trackEnd or queueEnd event while changing the node

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -991,7 +991,10 @@ export class Player {
 
         const data = this.toJSON();
         const currentTrack = this.queue.current;
-        if (!this.voice.endpoint || !this.voice.sessionId || !this.voice.token)
+        const storedVoice = this.getData<LavalinkPlayerVoiceOptions | undefined>("internal_nodeMoveVoiceData");
+        const voiceData =
+            this.voice?.endpoint && this.voice?.sessionId && this.voice?.token ? this.voice : storedVoice;
+        if (!voiceData?.endpoint || !voiceData?.sessionId || !voiceData?.token)
             throw new Error("Voice Data is missing, can't change the node");
         this.setData("internal_nodeChanging", true); // This will stop execution of trackEnd or queueEnd event while changing the node
         if (this.node.connected) await this.node.destroyPlayer(this.guildId); // destroy the player on the currentNode if it's connected
@@ -1038,10 +1041,10 @@ export class Player {
                         paused: this.paused,
                     }),
                     voice: {
-                        token: this.voice.token,
-                        endpoint: this.voice.endpoint,
-                        sessionId: this.voice.sessionId,
-                        channelId: this.voice.channelId,
+                        token: voiceData.token,
+                        endpoint: voiceData.endpoint,
+                        sessionId: voiceData.sessionId,
+                        channelId: voiceData.channelId || this.voice.channelId || this.options.voiceChannelId,
                     },
                 },
             });
@@ -1058,6 +1061,7 @@ export class Player {
             throw new Error(`Failed to change the node: ${error}`);
         } finally {
             this.setData("internal_nodeChanging", undefined);
+            this.setData("internal_nodeMoveVoiceData", undefined);
         }
     }
 
@@ -1076,8 +1080,8 @@ export class Player {
         try {
             if (!node)
                 node = Array.from(this.LavalinkManager.nodeManager.leastUsedNodes("playingPlayers")).find(
-                    (n) => n.connected && n.options.id !== this.node.options.id,
-                ).id;
+                    (n) => n.connected && !!n.sessionId && n.options.id !== this.node.options.id,
+                )?.id;
             if (!node || !this.LavalinkManager.nodeManager.nodes.get(node))
                 throw new RangeError("No nodes are available.");
             if (this.node.options.id === node) return this;

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -991,9 +991,7 @@ export class Player {
 
         const data = this.toJSON();
         const currentTrack = this.queue.current;
-        const storedVoice = this.getData<LavalinkPlayerVoiceOptions | undefined>("internal_nodeMoveVoiceData");
-        const voiceData = this.voice?.endpoint && this.voice?.sessionId && this.voice?.token ? this.voice : storedVoice;
-        if (!voiceData?.endpoint || !voiceData?.sessionId || !voiceData?.token)
+        if (!this.voice.endpoint || !this.voice.sessionId || !this.voice.token)
             throw new Error("Voice Data is missing, can't change the node");
         this.setData("internal_nodeChanging", true); // This will stop execution of trackEnd or queueEnd event while changing the node
         if (this.node.connected) await this.node.destroyPlayer(this.guildId); // destroy the player on the currentNode if it's connected
@@ -1040,10 +1038,10 @@ export class Player {
                         paused: this.paused,
                     }),
                     voice: {
-                        token: voiceData.token,
-                        endpoint: voiceData.endpoint,
-                        sessionId: voiceData.sessionId,
-                        channelId: voiceData.channelId || this.voice.channelId || this.options.voiceChannelId,
+                        token: this.voice.token,
+                        endpoint: this.voice.endpoint,
+                        sessionId: this.voice.sessionId,
+                        channelId: this.voice.channelId,
                     },
                 },
             });
@@ -1060,7 +1058,6 @@ export class Player {
             throw new Error(`Failed to change the node: ${error}`);
         } finally {
             this.setData("internal_nodeChanging", undefined);
-            this.setData("internal_nodeMoveVoiceData", undefined);
         }
     }
 

--- a/src/structures/Types/Manager.ts
+++ b/src/structures/Types/Manager.ts
@@ -370,23 +370,34 @@ export interface ManagerOptions<CustomPlayerT extends Player = Player> {
     httpHeaders?: Record<string, string>;
     /** Advanced Options for the Library, which may or may not be "library breaking" */
     advancedOptions?: {
-        /** Max duration for that the filter fix duration works (in ms) - default is 8mins */
-        maxFilterFixDuration?: number;
-        /** Enable Debug event */
-        enableDebugEvents?: boolean;
-        /** optional */
-        debugOptions?: {
-            /** For logging custom searches */
-            logCustomSearches?: boolean;
-            /** logs for debugging the "no-Audio" playing error */
-            noAudio?: boolean;
-            /** For Logging the Destroy function */
-            playerDestroy?: {
-                /** To show the debug reason at all times. */
-                debugLog?: boolean;
-                /** If you get 'Error: Use Player#destroy("reason") not LavalinkManager#deletePlayer() to stop the Player' put it on true */
-                dontThrowError?: boolean;
-            };
+    /** Max duration for that the filter fix duration works (in ms) - default is 8mins */
+    maxFilterFixDuration?: number;
+    /** Enable Debug event */
+    enableDebugEvents?: boolean;
+    /** optional */
+    debugOptions?: {
+        /** For logging custom searches */
+        logCustomSearches?: boolean;
+        /** logs for debugging the "no-Audio" playing error */
+        noAudio?: boolean;
+        /** For Logging the Destroy function */
+        playerDestroy?: {
+            /** To show the debug reason at all times. */
+            debugLog?: boolean;
+            /** If you get 'Error: Use Player#destroy("reason") not LavalinkManager#deletePlayer() to stop the Player' put it on true */
+            dontThrowError?: boolean;
         };
     };
+    /** Player migration configuration */
+    playerMigration?: {
+        /** Maximum number of players migrated concurrently. Default: 5 */
+        concurrency?: number;
+
+        /** Maximum number of concurrent migrations to a single target node. Default: 2 */
+        perTargetConcurrency?: number;
+
+        /** Maximum time to wait for migration capacity before retrying. Default: 50ms */
+        backpressureDelayMs?: number;
+    };
+};
 }


### PR DESCRIPTION
## What this fixes

Automatic player migration could fail when a node disconnected, including cases where replacement nodes were connected but not ready and migration requests overloaded a replacement node.

### Changes

- Only migrate to nodes with an active Lavalink session.
- Migrate with bounded concurrency (default: 5 overall and 2 per target) instead of issuing every move at once.
- Apply the same migration path when destroying a node with `movePlayers: true`.
- Keep migration reservations and capacity waiters on each `NodeManager`, preventing separate `LavalinkManager` instances from sharing state.
- Restore the source-node association before retrying a failed move to another target.
- Emit the disconnect event and start the source-node reconnect flow before awaiting the migration batch.

### Validation

- `npm run build`
- `npx oxfmt --check src/structures/Node.ts src/structures/Player.ts`
- `npx oxlint src/structures/Node.ts src/structures/Player.ts`