### PR TITLE
docs: add Listen bot to Used In list

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ This client powers various Discord bots:
     - [BeatDock](https://github.com/lazaroagomez/BeatDock) (@lazaroagomez)
     - [Nazha](https://top.gg/bot/1124681788070055967) (@Nazha-Team)
     - [Arii Music](https://arimusic.me/) (@friston_ae)
+    - [Listen](https://listen.ac) (@gabcaua)
 
 ---
 


### PR DESCRIPTION
### Description

Adds **Listen** to the "Bots By Community (Users)" showcase in the README.

- **Website:** https://listen.ac
- **Stats:** ~19k servers | 1.8M users
- **Developer:** @gabcaua

Listen is a production Discord music bot focused on low-latency audio, live word-synced lyrics, and smooth beat-matched transitions (AutoMix), using `lavalink-client` across active voice sessions.